### PR TITLE
Update website to 'www'

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-thebikeshed.io
+www.thebikeshed.io


### PR DESCRIPTION
This is temporary until we can find a solution, that will probably involve a load balancer.

Anyway.... CNAMEs cannot be the root record, unless we have `ALIAS` support (which our DNS does not). The best we can do for now is the old classic... www.thebikeshed.io.

Until we get a little more HW in place, this will have to do.
